### PR TITLE
meta: Fix the Linux libxcb linking error

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Prep container
         run: |
           sudo apt-get update
-          sudo apt-get install --no-install-recommends -y libdbus-1-dev dbus libxcb1-dev libxcb
+          sudo apt-get install --no-install-recommends -y libdbus-1-dev dbus libxcb1-dev
 
       - name: Build (dbg)
         run: cargo build --verbose

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Prep container
         run: |
           sudo apt-get update
-          sudo apt-get install --no-install-recommends -y libdbus-1-dev dbus
+          sudo apt-get install --no-install-recommends -y libdbus-1-dev dbus libxcb1-dev libxcb
 
       - name: Build (dbg)
         run: cargo build --verbose


### PR DESCRIPTION
We've been getting linux build failures with

> /usr/bin/ld: cannot find -lxcb: No such file or directory

I think the `libxcb1-dev` will take care of it, but install `libxcb` as well just to be safe.