### PR TITLE
Add pre-push hooks for Mac/Linux and Windows

### DIFF
--- a/.githooks/unix/pre-push
+++ b/.githooks/unix/pre-push
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Pre-push hook: runs the same checks as CI
+# Silent on success, shows failed commands on failure
+
+failures=()
+
+# Format check
+if ! cargo fmt -- --check >/dev/null 2>&1; then
+    failures+=("cargo fmt -- --check")
+fi
+
+# Build
+if ! cargo build >/dev/null 2>&1; then
+    failures+=("cargo build")
+fi
+
+# Clippy
+if ! cargo clippy -- -D warnings >/dev/null 2>&1; then
+    failures+=("cargo clippy -- -D warnings")
+fi
+
+# Report failures
+if [ ${#failures[@]} -gt 0 ]; then
+    echo "Push blocked. ${#failures[@]} check(s) failed."
+    echo ""
+    echo "Run to see details:"
+    for cmd in "${failures[@]}"; do
+        echo "  $cmd"
+    done
+    exit 1
+fi

--- a/.githooks/windows/pre-push
+++ b/.githooks/windows/pre-push
@@ -1,0 +1,37 @@
+#!/usr/bin/env pwsh
+# Pre-push hook for Windows: runs the same checks as CI
+# Requires PowerShell Core (pwsh) - install from https://github.com/PowerShell/PowerShell
+# Silent on success, shows failed commands on failure
+#
+# To use: git config core.hooksPath .githooks/windows
+
+$failures = @()
+
+# Format check
+$null = cargo fmt -- --check 2>&1
+if ($LASTEXITCODE -ne 0) {
+    $failures += "cargo fmt -- --check"
+}
+
+# Build
+$null = cargo build 2>&1
+if ($LASTEXITCODE -ne 0) {
+    $failures += "cargo build"
+}
+
+# Clippy
+$null = cargo clippy -- -D warnings 2>&1
+if ($LASTEXITCODE -ne 0) {
+    $failures += "cargo clippy -- -D warnings"
+}
+
+# Report failures
+if ($failures.Count -gt 0) {
+    Write-Host "Push blocked. $($failures.Count) check(s) failed."
+    Write-Host ""
+    Write-Host "Run to see details:"
+    foreach ($cmd in $failures) {
+        Write-Host "  $cmd"
+    }
+    exit 1
+}


### PR DESCRIPTION
Runs format check, build, and clippy before push to catch CI failures locally. Silent on success, shows failed commands on failure.

Platform-specific hooks in subdirectories:
- .githooks/unix/pre-push - Bash script for Mac/Linux
- .githooks/windows/pre-push - PowerShell script for Windows

To enable:
  Mac/Linux: git config core.hooksPath .githooks/unix
  Windows:   git config core.hooksPath .githooks/windows