### PR TITLE
Add retention-based cleanup of processed shot directories

### DIFF
--- a/src/back_filler.rs
+++ b/src/back_filler.rs
@@ -7,7 +7,7 @@ use chrono::{DateTime, Datelike, Local, NaiveDate};
 use glob::glob;
 use log::{info, warn};
 use std::collections::HashSet;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::result::Result;
 
 pub struct BackFiller {
@@ -74,6 +74,16 @@ impl BackFiller {
         }
 
         info!("Done backfilling movies");
+
+        if let Some(keep_count) = self.config.keep_shots_days {
+            DirManager::cleanup_old_shot_dirs(
+                Path::new(&self.config.shot_output_dir),
+                Path::new(&self.config.vid_output_dir),
+                &self.config.video_type,
+                keep_count,
+                self.today,
+            );
+        }
     }
 
     fn discover_vids(&self) -> Result<HashSet<NaiveDate>, Error> {

--- a/src/dir_manager.rs
+++ b/src/dir_manager.rs
@@ -178,6 +178,11 @@ impl DirManager {
         keep_count: u32,
         today: NaiveDate,
     ) {
+        info!(
+            "Checking for old shot dirs to clean up (keeping {} days)",
+            keep_count
+        );
+
         let shot_glob = shot_root
             .join("[0-9][0-9][0-9][0-9]")
             .join("[0-1][0-9]")

--- a/src/dir_manager.rs
+++ b/src/dir_manager.rs
@@ -1,7 +1,8 @@
 use anyhow::Error;
-use chrono::{Datelike, Local};
+use chrono::{Datelike, Local, NaiveDate};
 use csv::{Reader, Writer};
-use log::{error, info, warn};
+use glob::glob;
+use log::{debug, error, info, warn};
 use std::fs::create_dir_all;
 use std::path::{Path, PathBuf};
 
@@ -163,5 +164,273 @@ impl DirManager {
 
         // Generate if missing
         Self::generate_metadata(in_dir, extension)
+    }
+
+    /// Remove old shot directories that have already been converted to videos.
+    ///
+    /// Discovers all shot directories under `shot_root`, excludes `today`, sorts
+    /// by date descending, keeps the most recent `keep_count` entries, and deletes
+    /// the rest if a corresponding video file exists with non-zero size.
+    pub fn cleanup_old_shot_dirs(
+        shot_root: &Path,
+        vid_dir: &Path,
+        video_type: &str,
+        keep_count: u32,
+        today: NaiveDate,
+    ) {
+        let shot_glob = shot_root
+            .join("[0-9][0-9][0-9][0-9]")
+            .join("[0-1][0-9]")
+            .join("[0-3][0-9]");
+
+        let ok_matches = match glob(shot_glob.to_str().unwrap()) {
+            Ok(paths) => paths.filter_map(Result::ok),
+            Err(e) => {
+                warn!("Failed to glob shot directories: {e}");
+                return;
+            }
+        };
+
+        let mut dated_dirs: Vec<(NaiveDate, PathBuf)> = Vec::new();
+
+        for entry in ok_matches {
+            if !entry.is_dir() {
+                continue;
+            }
+
+            if let Some((year, month, day)) = Self::parse_date_from_shot_dir(&entry) {
+                if let Some(date) = NaiveDate::from_ymd_opt(year as i32, month as u32, day as u32) {
+                    if date == today {
+                        continue;
+                    }
+                    dated_dirs.push((date, entry));
+                }
+            }
+        }
+
+        // Sort descending (most recent first)
+        dated_dirs.sort_by(|a, b| b.0.cmp(&a.0));
+
+        // Skip the first keep_count entries
+        let to_delete = dated_dirs.into_iter().skip(keep_count as usize);
+
+        for (date, shot_dir) in to_delete {
+            let video_file = vid_dir.join(format!(
+                "ompd-{}-{:02}-{:02}.{}",
+                date.year(),
+                date.month(),
+                date.day(),
+                video_type
+            ));
+
+            match std::fs::metadata(&video_file) {
+                Ok(meta) if meta.len() > 0 => {
+                    info!(
+                        "Cleaning up shot dir {} (video exists at {})",
+                        shot_dir.display(),
+                        video_file.display()
+                    );
+                    Self::cleanup_shot_dir(&shot_dir, shot_root);
+                }
+                Ok(_) => {
+                    debug!("Skipping {} — video file is empty", shot_dir.display());
+                }
+                Err(_) => {
+                    debug!(
+                        "Skipping {} — no video at {}",
+                        shot_dir.display(),
+                        video_file.display()
+                    );
+                }
+            }
+        }
+    }
+
+    /// Remove a shot directory and clean up empty parent directories up to shot_root.
+    fn cleanup_shot_dir(shot_dir: &Path, shot_root: &Path) {
+        if let Err(e) = std::fs::remove_dir_all(shot_dir) {
+            warn!("Failed to remove shot dir {}: {e}", shot_dir.display());
+            return;
+        }
+
+        // Walk parents up to (but not including) shot_root, removing empty dirs
+        let mut current = shot_dir.parent();
+        while let Some(parent) = current {
+            if parent == shot_root {
+                break;
+            }
+            // remove_dir only succeeds if the directory is empty
+            if std::fs::remove_dir(parent).is_err() {
+                break;
+            }
+            current = parent.parent();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::File;
+    use std::io::Write;
+
+    /// Helper to create a shot directory structure YYYY/MM/DD under root
+    fn create_shot_dir(root: &Path, year: u16, month: u8, day: u8) -> PathBuf {
+        let dir = DirManager::shot_dir_for_date(root, year, month, day);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    /// Helper to create a video file with non-zero content
+    fn create_video(vid_dir: &Path, year: u16, month: u8, day: u8, ext: &str) {
+        let path = vid_dir.join(format!("ompd-{year}-{month:02}-{day:02}.{ext}"));
+        let mut f = File::create(path).unwrap();
+        f.write_all(b"fake video data").unwrap();
+    }
+
+    #[test]
+    fn test_cleanup_shot_dir_removes_dir_and_empty_parents() {
+        let temp = tempfile::tempdir().unwrap();
+        let shot_root = temp.path().join("shots");
+        let shot_dir = create_shot_dir(&shot_root, 2024, 3, 15);
+
+        // Put a file in the shot dir
+        File::create(shot_dir.join("00000.jpeg")).unwrap();
+
+        DirManager::cleanup_shot_dir(&shot_dir, &shot_root);
+
+        assert!(!shot_dir.exists(), "Shot dir should be removed");
+        // Month dir (03) should be removed since it's now empty
+        assert!(
+            !shot_root.join("2024").join("03").exists(),
+            "Empty month dir should be removed"
+        );
+        // Year dir (2024) should be removed since it's now empty
+        assert!(
+            !shot_root.join("2024").exists(),
+            "Empty year dir should be removed"
+        );
+        // shot_root itself should still exist
+        assert!(shot_root.exists(), "Shot root should not be removed");
+    }
+
+    #[test]
+    fn test_cleanup_shot_dir_preserves_nonempty_parents() {
+        let temp = tempfile::tempdir().unwrap();
+        let shot_root = temp.path().join("shots");
+
+        // Create two days in the same month
+        let dir_15 = create_shot_dir(&shot_root, 2024, 3, 15);
+        let dir_16 = create_shot_dir(&shot_root, 2024, 3, 16);
+
+        File::create(dir_15.join("00000.jpeg")).unwrap();
+        File::create(dir_16.join("00000.jpeg")).unwrap();
+
+        // Only remove day 15
+        DirManager::cleanup_shot_dir(&dir_15, &shot_root);
+
+        assert!(!dir_15.exists(), "Shot dir 15 should be removed");
+        assert!(dir_16.exists(), "Shot dir 16 should still exist");
+        assert!(
+            shot_root.join("2024").join("03").exists(),
+            "Month dir should still exist (has day 16)"
+        );
+    }
+
+    #[test]
+    fn test_cleanup_old_shot_dirs_keeps_n_most_recent() {
+        let temp = tempfile::tempdir().unwrap();
+        let shot_root = temp.path().join("shots");
+        let vid_dir = temp.path().join("vids");
+        std::fs::create_dir_all(&vid_dir).unwrap();
+
+        let today = NaiveDate::from_ymd_opt(2024, 3, 20).unwrap();
+
+        // Create 5 shot dirs (not including today)
+        for day in 15..=19 {
+            create_shot_dir(&shot_root, 2024, 3, day);
+            create_video(&vid_dir, 2024, 3, day, "mp4");
+        }
+
+        // Keep 2 most recent
+        DirManager::cleanup_old_shot_dirs(&shot_root, &vid_dir, "mp4", 2, today);
+
+        // Days 18 and 19 should remain (most recent 2)
+        assert!(
+            DirManager::shot_dir_for_date(&shot_root, 2024, 3, 19).exists(),
+            "Day 19 should be kept"
+        );
+        assert!(
+            DirManager::shot_dir_for_date(&shot_root, 2024, 3, 18).exists(),
+            "Day 18 should be kept"
+        );
+        // Days 15, 16, 17 should be deleted
+        assert!(
+            !DirManager::shot_dir_for_date(&shot_root, 2024, 3, 15).exists(),
+            "Day 15 should be deleted"
+        );
+        assert!(
+            !DirManager::shot_dir_for_date(&shot_root, 2024, 3, 16).exists(),
+            "Day 16 should be deleted"
+        );
+        assert!(
+            !DirManager::shot_dir_for_date(&shot_root, 2024, 3, 17).exists(),
+            "Day 17 should be deleted"
+        );
+    }
+
+    #[test]
+    fn test_cleanup_old_shot_dirs_skips_dirs_without_video() {
+        let temp = tempfile::tempdir().unwrap();
+        let shot_root = temp.path().join("shots");
+        let vid_dir = temp.path().join("vids");
+        std::fs::create_dir_all(&vid_dir).unwrap();
+
+        let today = NaiveDate::from_ymd_opt(2024, 3, 20).unwrap();
+
+        // Create 3 shot dirs, but only 1 has a video
+        create_shot_dir(&shot_root, 2024, 3, 15);
+        create_shot_dir(&shot_root, 2024, 3, 16);
+        create_video(&vid_dir, 2024, 3, 16, "mp4");
+        create_shot_dir(&shot_root, 2024, 3, 17);
+
+        // Keep 0 (would delete everything old)
+        DirManager::cleanup_old_shot_dirs(&shot_root, &vid_dir, "mp4", 0, today);
+
+        // Day 16 should be deleted (has video)
+        assert!(
+            !DirManager::shot_dir_for_date(&shot_root, 2024, 3, 16).exists(),
+            "Day 16 should be deleted (has video)"
+        );
+        // Days 15, 17 should still exist (no video)
+        assert!(
+            DirManager::shot_dir_for_date(&shot_root, 2024, 3, 15).exists(),
+            "Day 15 should remain (no video)"
+        );
+        assert!(
+            DirManager::shot_dir_for_date(&shot_root, 2024, 3, 17).exists(),
+            "Day 17 should remain (no video)"
+        );
+    }
+
+    #[test]
+    fn test_cleanup_old_shot_dirs_never_deletes_today() {
+        let temp = tempfile::tempdir().unwrap();
+        let shot_root = temp.path().join("shots");
+        let vid_dir = temp.path().join("vids");
+        std::fs::create_dir_all(&vid_dir).unwrap();
+
+        let today = NaiveDate::from_ymd_opt(2024, 3, 15).unwrap();
+
+        create_shot_dir(&shot_root, 2024, 3, 15);
+        create_video(&vid_dir, 2024, 3, 15, "mp4");
+
+        // Keep 0, but today should still survive
+        DirManager::cleanup_old_shot_dirs(&shot_root, &vid_dir, "mp4", 0, today);
+
+        assert!(
+            DirManager::shot_dir_for_date(&shot_root, 2024, 3, 15).exists(),
+            "Today's directory should never be deleted"
+        );
     }
 }

--- a/src/movie_maker.rs
+++ b/src/movie_maker.rs
@@ -3,6 +3,7 @@ use crate::DirManager;
 use crate::FrameMetadata;
 use crate::DEFAULT_FRAME_DIMENSIONS;
 use anyhow::Error;
+use chrono::{Datelike, Local, NaiveDate};
 use log::{debug, error, info, warn};
 use std::collections::HashMap;
 use std::fs;
@@ -90,6 +91,20 @@ impl MovieMaker {
             let err = format!("Issue with ffmpeg - last line of stderr: {}", last_line);
             error!("{}", &err);
             panic!("{}", &err);
+        }
+
+        if let Some(keep_count) = self.config.keep_shots_days {
+            let today = Local::now();
+            let today_date = NaiveDate::from_ymd_opt(today.year(), today.month(), today.day())
+                .expect("Invalid date from Local::now()");
+
+            DirManager::cleanup_old_shot_dirs(
+                Path::new(&self.config.shot_output_dir),
+                Path::new(&self.config.vid_output_dir),
+                &self.config.video_type,
+                keep_count,
+                today_date,
+            );
         }
 
         info!("All done with {input_dir:?}!");

--- a/tests/multi_resolution_integration.rs
+++ b/tests/multi_resolution_integration.rs
@@ -36,6 +36,7 @@ fn test_config(shot_dir: &str, vid_dir: &str) -> ompd::Config {
         shot_type: "webp".to_string(),
         video_type: "mp4".to_string(),
         vid_scale_factor: 1.0,
+        keep_shots_days: None,
     }
 }
 


### PR DESCRIPTION
Add a `keep_shots_days` config option that controls how many recorded days of shot directories to keep. Only directories that actually exist are counted (weekends/gaps don't count), and a directory is only deleted once its corresponding video file exists with non-zero size. Today's directory is never deleted.

Cleanup runs after video creation in MovieMaker and after the backfill sweep in BackFiller, both calling the same DirManager function.

The field defaults to None (absent from JSON), preserving the current behavior of keeping shot directories forever.